### PR TITLE
[Fix] 상태창 나가기 버그 수정(-장범)

### DIFF
--- a/ZzabDenRing/ScreenDisplay.cs
+++ b/ZzabDenRing/ScreenDisplay.cs
@@ -43,7 +43,7 @@ public class ScreenDisplay
                 navToInventory: () => { _backStack.Push(ScreenType.Inventory); }
             ),
             ScreenType.Shop => new ShopScreen(popBackStack: () => { _backStack.Pop(); }),
-            ScreenType.Status => new StatusScreen(navToMain: () => { }),
+            ScreenType.Status => new StatusScreen(navToMain: () => { _backStack.Push(ScreenType.Main); }),
             ScreenType.Equipment => new EquipmentScreen(
                 popBackStack: () => { _backStack.Pop(); }
             ),


### PR DESCRIPTION
-상태창에서 나가기기능이 안됨
-ScreenDisplay.cs에서 46번줄을
ScreenType.Status => new StatusScreen(navToMain: () => { _backStack.Push(ScreenType.Main); }), 이렇게 수정